### PR TITLE
Added Support for custom Generate function

### DIFF
--- a/pkg/configmap/configmap.go
+++ b/pkg/configmap/configmap.go
@@ -86,7 +86,13 @@ func MaybeUpdate(original interfaces.Object, new interfaces.Object) (bool, error
 // Create generates the ConfigMap as per the `Conf` struct passed and
 // creates it in the cluster
 func Create(c Conf) (reconcile.Result, error) {
-	cm, err := GenerateConfigMap(c)
+	var cm *corev1.ConfigMap
+	var err error
+	if c.GenConfigMapFunc != nil {
+		cm, err = c.GenConfigMapFunc(c)
+	} else {
+		cm, err = GenerateConfigMap(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate configmap")
 	}
@@ -111,7 +117,13 @@ func Create(c Conf) (reconcile.Result, error) {
 // ConfigMaps, it uses `MaybeUpdate` function by default but can also
 // use `MaybeUpdateFunc` from `Conf` if passed.
 func Update(c Conf) (reconcile.Result, error) {
-	cm, err := GenerateConfigMap(c)
+	var cm *corev1.ConfigMap
+	var err error
+	if c.GenConfigMapFunc != nil {
+		cm, err = c.GenConfigMapFunc(c)
+	} else {
+		cm, err = GenerateConfigMap(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate configmap")
 	}
@@ -142,7 +154,13 @@ func Update(c Conf) (reconcile.Result, error) {
 // functions. It creates the ConfigMap object if it is not already in
 // the cluster and updates the ConfigMap if one exists.
 func CreateOrUpdate(c Conf) (reconcile.Result, error) {
-	cm, err := GenerateConfigMap(c)
+	var cm *corev1.ConfigMap
+	var err error
+	if c.GenConfigMapFunc != nil {
+		cm, err = c.GenConfigMapFunc(c)
+	} else {
+		cm, err = GenerateConfigMap(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate configmap")
 	}
@@ -175,7 +193,13 @@ func CreateOrUpdate(c Conf) (reconcile.Result, error) {
 // (only ObjectMeta of generated ConfigMap is required) and deletes it
 // from the cluster
 func Delete(c Conf) (reconcile.Result, error) {
-	cm, err := GenerateConfigMap(c)
+	var cm *corev1.ConfigMap
+	var err error
+	if c.GenConfigMapFunc != nil {
+		cm, err = c.GenConfigMapFunc(c)
+	} else {
+		cm, err = GenerateConfigMap(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate configmap")
 	}

--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -201,6 +201,12 @@ func TestCreate(t *testing.T) {
 		}})
 		assert.Error(t, err)
 	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := configmap.Create(configmap.Conf{GenConfigMapFunc: func(configmap.Conf) (*corev1.ConfigMap, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
 	t.Run("failed to create", func(t *testing.T) {
 		i, r := mockSetup(controller)
 		_, err := configmap.Create(configmap.Conf{
@@ -228,6 +234,12 @@ func TestUpdate(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := configmap.Update(configmap.Conf{GenDataFunc: func(interfaces.Object) (map[string]string, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := configmap.Update(configmap.Conf{GenConfigMapFunc: func(configmap.Conf) (*corev1.ConfigMap, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)
@@ -268,6 +280,12 @@ func TestCreateOrUpdate(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := configmap.CreateOrUpdate(configmap.Conf{GenDataFunc: func(interfaces.Object) (map[string]string, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := configmap.CreateOrUpdate(configmap.Conf{GenConfigMapFunc: func(configmap.Conf) (*corev1.ConfigMap, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)
@@ -321,6 +339,12 @@ func TestDelete(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := configmap.Delete(configmap.Conf{GenDataFunc: func(interfaces.Object) (map[string]string, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := configmap.Delete(configmap.Conf{GenConfigMapFunc: func(configmap.Conf) (*corev1.ConfigMap, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)

--- a/pkg/configmap/types.go
+++ b/pkg/configmap/types.go
@@ -4,7 +4,12 @@ import (
 	"github.com/ankitrgadiya/operatorlib/pkg/interfaces"
 	"github.com/ankitrgadiya/operatorlib/pkg/meta"
 	"github.com/ankitrgadiya/operatorlib/pkg/operation"
+
+	corev1 "k8s.io/api/core/v1"
 )
+
+// GenConfigMapFunc defines a function which generates ConfigMap.
+type GenConfigMapFunc func(Conf) (*corev1.ConfigMap, error)
 
 // GenDataFunc defines a function which generates data (string map)
 // for Configmap.
@@ -46,6 +51,12 @@ type Conf struct {
 	operation.AfterUpdateFunc
 	// AfterDeleteFunc hook is called after deleting the Configmap
 	operation.AfterDeleteFunc
+	// GenConfigMapFunc defines a function to generate the Configmap
+	// object. The package comes with default configmap generator
+	// function which is used by operation functions. By specifying
+	// this field, user can override the default function with a
+	// custom one.
+	GenConfigMapFunc
 	// GenDataFunc defines a function to generate data for Configmap
 	GenDataFunc
 	// GenBinaryDataFunc defines a function to generate binary data

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -99,7 +99,13 @@ func MaybeUpdate(original interfaces.Object, new interfaces.Object) (bool, error
 // Create generates Secret as per the `Conf` struct passed and creates
 // it in the cluster
 func Create(c Conf) (reconcile.Result, error) {
-	s, err := GenerateSecret(c)
+	var s *corev1.Secret
+	var err error
+	if c.GenSecretFunc != nil {
+		s, err = c.GenSecretFunc(c)
+	} else {
+		s, err = GenerateSecret(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate secret")
 	}
@@ -123,7 +129,13 @@ func Create(c Conf) (reconcile.Result, error) {
 // it uses `MaybeUpdate` function by default but can also use
 // `MaybeUpdateFunc` from `Conf` if passed.
 func Update(c Conf) (reconcile.Result, error) {
-	s, err := GenerateSecret(c)
+	var s *corev1.Secret
+	var err error
+	if c.GenSecretFunc != nil {
+		s, err = c.GenSecretFunc(c)
+	} else {
+		s, err = GenerateSecret(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate secret")
 	}
@@ -154,7 +166,13 @@ func Update(c Conf) (reconcile.Result, error) {
 // functions. It creates the Secret object if it is not already in the
 // cluster and updates the Secret if one exists.
 func CreateOrUpdate(c Conf) (reconcile.Result, error) {
-	s, err := GenerateSecret(c)
+	var s *corev1.Secret
+	var err error
+	if c.GenSecretFunc != nil {
+		s, err = c.GenSecretFunc(c)
+	} else {
+		s, err = GenerateSecret(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate secret")
 	}
@@ -187,7 +205,13 @@ func CreateOrUpdate(c Conf) (reconcile.Result, error) {
 // ObjectMeta of generated Secret is required) and deletes it from the
 // cluster
 func Delete(c Conf) (reconcile.Result, error) {
-	s, err := GenerateSecret(c)
+	var s *corev1.Secret
+	var err error
+	if c.GenSecretFunc != nil {
+		s, err = c.GenSecretFunc(c)
+	} else {
+		s, err = GenerateSecret(c)
+	}
 	if err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to generate secret")
 	}

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -190,6 +190,12 @@ func TestCreate(t *testing.T) {
 		}})
 		assert.Error(t, err)
 	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := secret.Create(secret.Conf{GenSecretFunc: func(secret.Conf) (*corev1.Secret, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
 	t.Run("failed to create", func(t *testing.T) {
 		i, r := mockSetup(controller)
 		_, err := secret.Create(secret.Conf{
@@ -225,6 +231,12 @@ func TestUpdate(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := secret.Update(secret.Conf{GenDataFunc: func(interfaces.Object) (map[string][]byte, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := secret.Update(secret.Conf{GenSecretFunc: func(secret.Conf) (*corev1.Secret, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)
@@ -316,6 +328,12 @@ func TestCreateOrUpdate(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := secret.CreateOrUpdate(secret.Conf{GenDataFunc: func(interfaces.Object) (map[string][]byte, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := secret.CreateOrUpdate(secret.Conf{GenSecretFunc: func(secret.Conf) (*corev1.Secret, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)
@@ -420,6 +438,12 @@ func TestDelete(t *testing.T) {
 
 	t.Run("failed to generate", func(t *testing.T) {
 		_, err := secret.Delete(secret.Conf{GenDataFunc: func(interfaces.Object) (map[string][]byte, error) {
+			return nil, errors.New("test error")
+		}})
+		assert.Error(t, err)
+	})
+	t.Run("failed to generate using custom generator function", func(t *testing.T) {
+		_, err := secret.Delete(secret.Conf{GenSecretFunc: func(secret.Conf) (*corev1.Secret, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)

--- a/pkg/secret/types.go
+++ b/pkg/secret/types.go
@@ -4,7 +4,12 @@ import (
 	"github.com/ankitrgadiya/operatorlib/pkg/interfaces"
 	"github.com/ankitrgadiya/operatorlib/pkg/meta"
 	"github.com/ankitrgadiya/operatorlib/pkg/operation"
+
+	corev1 "k8s.io/api/core/v1"
 )
+
+// GenSecretFunc defiens a function which generates Service object.
+type GenSecretFunc func(Conf) (*corev1.Secret, error)
 
 // GenDataFunc defines a function which generates map of string to
 // byte slice for `Data` field in Secret object
@@ -46,6 +51,11 @@ type Conf struct {
 	operation.AfterUpdateFunc
 	// AfterDeleteFunc hook is called after deleting the Secret
 	operation.AfterDeleteFunc
+	// GenSecretFunc defines a function to generate Secret object. The
+	// package comes with a default generate function. This field can
+	// be used to override the default function which is used by the
+	// operation functions.
+	GenSecretFunc
 	// GenDataFunc defines a function to generate data for Secret
 	GenDataFunc
 	// GenBinaryDataFunc defines a function to generate binary data


### PR DESCRIPTION
Resolves #13 

This PR implements the logic to accept custom generate function through package specific `Conf` struct which can be used by the operation functions of all object packages.