### PR TITLE
Fix: Generate ObjectMeta instead of Object in Delete functions

### DIFF
--- a/pkg/configmap/configmap_test.go
+++ b/pkg/configmap/configmap_test.go
@@ -338,13 +338,7 @@ func TestDelete(t *testing.T) {
 	defer controller.Finish()
 
 	t.Run("failed to generate", func(t *testing.T) {
-		_, err := configmap.Delete(configmap.Conf{GenDataFunc: func(interfaces.Object) (map[string]string, error) {
-			return nil, errors.New("test error")
-		}})
-		assert.Error(t, err)
-	})
-	t.Run("failed to generate using custom generator function", func(t *testing.T) {
-		_, err := configmap.Delete(configmap.Conf{GenConfigMapFunc: func(configmap.Conf) (*corev1.ConfigMap, error) {
+		_, err := configmap.Delete(configmap.Conf{GenLabelsFunc: func(interfaces.Object) (map[string]string, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -437,13 +437,7 @@ func TestDelete(t *testing.T) {
 	defer controller.Finish()
 
 	t.Run("failed to generate", func(t *testing.T) {
-		_, err := secret.Delete(secret.Conf{GenDataFunc: func(interfaces.Object) (map[string][]byte, error) {
-			return nil, errors.New("test error")
-		}})
-		assert.Error(t, err)
-	})
-	t.Run("failed to generate using custom generator function", func(t *testing.T) {
-		_, err := secret.Delete(secret.Conf{GenSecretFunc: func(secret.Conf) (*corev1.Secret, error) {
+		_, err := secret.Delete(secret.Conf{GenLabelsFunc: func(interfaces.Object) (map[string]string, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -218,25 +218,25 @@ func CreateOrUpdate(c Conf) (reconcile.Result, error) {
 	return result, nil
 }
 
-// Delete generates the Service as per the `Conf` struct passed (only
-// ObjectMeta of the generated Service is required) and deletes it
-// from the cluster
+// Delete generates the ObjectMeta for Service as per the `Conf`
+// struct passed and deletes it from the cluster
 func Delete(c Conf) (reconcile.Result, error) {
-	var s *corev1.Service
-	var err error
-	if c.GenServiceFunc != nil {
-		s, err = c.GenServiceFunc(c)
-	} else {
-		s, err = GenerateService(c)
-	}
+	om, err := meta.GenerateObjectMeta(meta.Conf{
+		Instance:           c.Instance,
+		Name:               c.Name,
+		Namespace:          c.Namespace,
+		GenLabelsFunc:      c.GenLabelsFunc,
+		GenAnnotationsFunc: c.GenAnnotationsFunc,
+		AppendLabels:       c.AppendLabels,
+	})
 	if err != nil {
-		return reconcile.Result{}, errors.Wrap(err, "failed to generate service")
+		return reconcile.Result{}, errors.Wrap(err, "failed to generate objectmeta for service")
 	}
 
 	result, err := operation.Delete(operation.Conf{
 		Instance:        c.Instance,
 		Reconcile:       c.Reconcile,
-		Object:          s,
+		Object:          &corev1.Service{ObjectMeta: *om},
 		AfterDeleteFunc: c.AfterDeleteFunc,
 	})
 	if err != nil {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -379,13 +379,7 @@ func TestDelete(t *testing.T) {
 	defer controller.Finish()
 
 	t.Run("failed to generate", func(t *testing.T) {
-		_, err := service.Delete(service.Conf{GenSelectorFunc: func(interfaces.Object) (map[string]string, error) {
-			return nil, errors.New("test error")
-		}})
-		assert.Error(t, err)
-	})
-	t.Run("failed to generate using custom generator function", func(t *testing.T) {
-		_, err := service.Delete(service.Conf{GenServiceFunc: func(service.Conf) (*corev1.Service, error) {
+		_, err := service.Delete(service.Conf{GenLabelsFunc: func(interfaces.Object) (map[string]string, error) {
 			return nil, errors.New("test error")
 		}})
 		assert.Error(t, err)


### PR DESCRIPTION
The Delete operation only requires the ObjectMeta details so there is
no use in generating the entire object. This changes the Delete
functions of all objects (service, configmap, secret) to directly
generate ObjectMeta and assign it to Empty Object. This is not a
breaking change.

Resolves #17